### PR TITLE
add show-taints flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 kubectl-node_resources
 kubectl-node-resource
 kubectl-node_resource
+.vscode

--- a/cmd/allocation.go
+++ b/cmd/allocation.go
@@ -116,6 +116,7 @@ Nodes can be filtered by a label selector.`,
 	cmd.Flags().BoolVar(&displayOpts.ShowGPU, "show-gpu", false, "Show GPU allocation/utilization")
 	cmd.Flags().StringVar(&displayOpts.GpuResourceKey, "gpu-resource-key", "nvidia.com/gpu", "The resource key for GPU counting")
 	cmd.Flags().BoolVar(&displayOpts.ShowFree, "show-free", false, "Show free CPU, Memory, Ephemeral Storage and GPU on each node")
+	cmd.Flags().BoolVar(&displayOpts.ShowTaints, "show-taints", false, "Show taints on each node")
 	cmd.Flags().StringVar(&summaryOpt, "summary", utils.SummaryShow, fmt.Sprintf("Summary display option: %s, %s, or %s", utils.SummaryShow, utils.SummaryOnly, utils.SummaryHide))
 	cmd.Flags().BoolVar(&displayOpts.JSONOutput, "json", false, "Output in JSON format")
 	opts.AddFlags(cmd.Flags())
@@ -274,6 +275,11 @@ func runAllocation(ctx context.Context, opts allocationRunOptions) error {
 				sort.Slice(currentHostPorts, func(i, j int) bool { return currentHostPorts[i] < currentHostPorts[j] })
 			}
 
+			var taints []corev1.Taint
+			if opts.DisplayOpts.ShowTaints {
+				taints = node.Spec.Taints
+			}
+
 			results[i] = utils.NodeResult{
 				Node:       node,
 				ReqCPU:     totalCPU,
@@ -281,6 +287,7 @@ func runAllocation(ctx context.Context, opts allocationRunOptions) error {
 				CPUPercent: cpuPercent,
 				MemPercent: memPercent,
 				HostPorts:  currentHostPorts,
+				Taints:     taints,
 				FreeCPU:    freeCPU,
 				FreeMem:    freeMem,
 				// Ephemeral Storage

--- a/cmd/display_options.go
+++ b/cmd/display_options.go
@@ -20,16 +20,17 @@ type DisplayOptions struct {
 	ShowMemory           bool
 	ShowFree             bool
 	ShowHostPorts        bool // Relevant for allocation command
+	ShowTaints           bool // Relevant for allocation command
 	ShowEphemeralStorage bool // Relevant for allocation command
 	ShowGPU              bool
 	GpuResourceKey       string
 	JSONOutput           bool
 }
 
-// HasPrimaryDataColumns checks if any of the primary data columns (CPU, Memory, EphemeralStorage, HostPorts, GPU)
+// HasPrimaryDataColumns checks if any of the primary data columns (CPU, Memory, EphemeralStorage, HostPorts, GPU, Taints)
 // are set to be displayed. This is used to determine if there's any content to show in a table.
 // ShowFree is not considered a "primary" column on its own as it typically accompanies other columns.
 // JSONOutput is an output format, not a column itself.
 func (do *DisplayOptions) HasPrimaryDataColumns() bool {
-	return do.ShowCPU || do.ShowMemory || do.ShowEphemeralStorage || do.ShowHostPorts || do.ShowGPU
+	return do.ShowCPU || do.ShowMemory || do.ShowEphemeralStorage || do.ShowHostPorts || do.ShowGPU || do.ShowTaints
 }

--- a/pkg/options/display_options.go
+++ b/pkg/options/display_options.go
@@ -20,16 +20,17 @@ type DisplayOptions struct {
 	ShowMemory           bool
 	ShowFree             bool
 	ShowHostPorts        bool // Relevant for allocation command
+	ShowTaints           bool // Relevant for allocation command
 	ShowEphemeralStorage bool // Relevant for allocation command
 	ShowGPU              bool
 	GpuResourceKey       string
 	JSONOutput           bool
 }
 
-// HasPrimaryDataColumns checks if any of the primary data columns (CPU, Memory, EphemeralStorage, HostPorts, GPU)
+// HasPrimaryDataColumns checks if any of the primary data columns (CPU, Memory, EphemeralStorage, HostPorts, GPU, Taints)
 // are set to be displayed. This is used to determine if there's any content to show in a table.
 // ShowFree is not considered a "primary" column on its own as it typically accompanies other columns.
 // JSONOutput is an output format, not a column itself.
 func (do *DisplayOptions) HasPrimaryDataColumns() bool {
-	return do.ShowCPU || do.ShowMemory || do.ShowEphemeralStorage || do.ShowHostPorts || do.ShowGPU
+	return do.ShowCPU || do.ShowMemory || do.ShowEphemeralStorage || do.ShowHostPorts || do.ShowGPU || do.ShowTaints
 }

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -66,6 +66,11 @@ func ToJSONNode(nodeRes utils.NodeResult, cmdType utils.CmdType, displayOpts opt
 			jsonNode.GPURequested = utils.FormatGPU(nodeRes.ReqGPU)
 			jsonNode.GPUPercent = nodeRes.GPUPercent
 		}
+		if displayOpts.ShowTaints {
+			for _, taint := range nodeRes.Taints {
+				jsonNode.Taints = append(jsonNode.Taints, taint.ToString())
+			}
+		}
 	} else if cmdType == utils.CmdTypeUtilization {
 		if displayOpts.ShowCPU {
 			jsonNode.CPUUsed = utils.FormatCPU(nodeRes.ReqCPU) // ReqCPU stores actual usage in utilization context

--- a/pkg/output/json_types.go
+++ b/pkg/output/json_types.go
@@ -23,28 +23,29 @@ package output
 // JSONNode represents a single node's data in JSON format.
 // Fields are tagged with `omitempty` if they are not always present.
 type JSONNode struct {
-	Name                        string  `json:"name"`
-	CPUAllocatable              string  `json:"cpuAllocatable"`
-	CPURequested                string  `json:"cpuRequested,omitempty"` // For allocation
-	CPUUsed                     string  `json:"cpuUsed,omitempty"`      // For utilization
-	CPUPercent                  float64 `json:"cpuPercent"`
-	MemoryAllocatable           string  `json:"memoryAllocatable"`
-	MemoryRequested             string  `json:"memoryRequested,omitempty"` // For allocation
-	MemoryUsed                  string  `json:"memoryUsed,omitempty"`      // For utilization
-	MemoryPercent               float64 `json:"memoryPercent"`
-	EphemeralStorageAllocatable string  `json:"ephemeralStorageAllocatable,omitempty"`
-	EphemeralStorageRequested   string  `json:"ephemeralStorageRequested,omitempty"` // For allocation
-	EphemeralStorageUsed        string  `json:"ephemeralStorageUsed,omitempty"`      // For utilization
-	EphemeralStoragePercent     float64 `json:"ephemeralStoragePercent,omitempty"`
-	FreeCPU                     string  `json:"freeCPU,omitempty"`              // If showFree is true
-	FreeMemory                  string  `json:"freeMemory,omitempty"`           // If showFree is true
-	FreeEphemeralStorage        string  `json:"freeEphemeralStorage,omitempty"` // If showFree and showEphemeralStorage are true
-	GPUAllocatable              string  `json:"gpuAllocatable,omitempty"`
-	GPURequested                string  `json:"gpuRequested,omitempty"` // For allocation
-	GPUUsed                     string  `json:"gpuUsed,omitempty"`      // For utilization
-	GPUPercent                  float64 `json:"gpuPercent,omitempty"`
-	FreeGPU                     string  `json:"freeGPU,omitempty"`   // If showFree and showGPU are true
-	HostPorts                   []int32 `json:"hostPorts,omitempty"` // For allocation, if showHostPorts is true
+	Name                        string   `json:"name"`
+	CPUAllocatable              string   `json:"cpuAllocatable"`
+	CPURequested                string   `json:"cpuRequested,omitempty"` // For allocation
+	CPUUsed                     string   `json:"cpuUsed,omitempty"`      // For utilization
+	CPUPercent                  float64  `json:"cpuPercent"`
+	MemoryAllocatable           string   `json:"memoryAllocatable"`
+	MemoryRequested             string   `json:"memoryRequested,omitempty"` // For allocation
+	MemoryUsed                  string   `json:"memoryUsed,omitempty"`      // For utilization
+	MemoryPercent               float64  `json:"memoryPercent"`
+	EphemeralStorageAllocatable string   `json:"ephemeralStorageAllocatable,omitempty"`
+	EphemeralStorageRequested   string   `json:"ephemeralStorageRequested,omitempty"` // For allocation
+	EphemeralStorageUsed        string   `json:"ephemeralStorageUsed,omitempty"`      // For utilization
+	EphemeralStoragePercent     float64  `json:"ephemeralStoragePercent,omitempty"`
+	FreeCPU                     string   `json:"freeCPU,omitempty"`              // If showFree is true
+	FreeMemory                  string   `json:"freeMemory,omitempty"`           // If showFree is true
+	FreeEphemeralStorage        string   `json:"freeEphemeralStorage,omitempty"` // If showFree and showEphemeralStorage are true
+	GPUAllocatable              string   `json:"gpuAllocatable,omitempty"`
+	GPURequested                string   `json:"gpuRequested,omitempty"` // For allocation
+	GPUUsed                     string   `json:"gpuUsed,omitempty"`      // For utilization
+	GPUPercent                  float64  `json:"gpuPercent,omitempty"`
+	FreeGPU                     string   `json:"freeGPU,omitempty"`   // If showFree and showGPU are true
+	HostPorts                   []int32  `json:"hostPorts,omitempty"` // For allocation, if showHostPorts is true
+	Taints                      []string `json:"taints,omitempty"`    // For allocation, if showTaints is true
 }
 
 // JSONPercentileDetail represents a single percentile data point in the summary.
@@ -59,6 +60,12 @@ type JSONPercentileDetail struct {
 type JSONHostPortSummary struct {
 	Port      int32 `json:"port"`
 	NodeCount int   `json:"nodeCount"`
+}
+
+// JSONTaintsSummary represents a taints usage summary.
+type JSONTaintsSummary struct {
+	Taint     string `json:"taint"`
+	NodeCount int    `json:"nodeCount"`
 }
 
 // JSONSummary represents the summary section of the JSON output.
@@ -80,7 +87,8 @@ type JSONSummary struct {
 	MemoryPercentiles             []JSONPercentileDetail `json:"memoryPercentiles,omitempty"` // Keeping existing percentile fields
 	EphemeralStoragePercentiles   []JSONPercentileDetail `json:"ephemeralStoragePercentiles,omitempty"`
 	GPUPercentiles                []JSONPercentileDetail `json:"gpuPercentiles,omitempty"`
-	TopHostPorts                  []JSONHostPortSummary  `json:"topHostPorts,omitempty"` // For allocation summary
+	TopHostPorts                  []JSONHostPortSummary  `json:"topHostPorts,omitempty"`  // For allocation summary
+	TaintsSummary                 []JSONTaintsSummary    `json:"taintsSummary,omitempty"` // For allocation summary
 }
 
 // JSONOutput is the root structure for the JSON output.

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -116,6 +116,47 @@ func GetResourcePercentilesData(results []utils.NodeResult, resourceName string,
 	return jsonData
 }
 
+// GetTaintsSummary returns an aggregated summary of node taints.
+func GetTaintsSummary(result []utils.NodeResult) []output.JSONTaintsSummary {
+	taintCounts := make(map[string]int)
+	totalTaintsFound := 0
+	for _, res := range result {
+		for _, taint := range res.Taints {
+			taintCounts[taint.ToString()]++
+			totalTaintsFound++
+		}
+	}
+
+	if totalTaintsFound == 0 {
+		return []output.JSONTaintsSummary{}
+	}
+
+	type taintStat struct {
+		taint string
+		count int
+	}
+	var stats []taintStat
+	for taint, count := range taintCounts {
+		stats = append(stats, taintStat{taint, count})
+	}
+
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].count != stats[j].count {
+			return stats[i].count > stats[j].count
+		}
+		return stats[i].taint < stats[j].taint
+	})
+
+	jsonData := make([]output.JSONTaintsSummary, 0, len(stats))
+	for _, stat := range stats {
+		jsonData = append(jsonData, output.JSONTaintsSummary{
+			Taint:     stat.taint,
+			NodeCount: stat.count,
+		})
+	}
+	return jsonData
+}
+
 // GetTopHostPortsData aggregates host port usage and returns the top 10.
 func GetTopHostPortsData(results []utils.NodeResult) []output.JSONHostPortSummary {
 	portCounts := make(map[int32]int)
@@ -252,6 +293,10 @@ func GetNodeResourceSummaryData(results []utils.NodeResult, displayOpts options.
 	if cmdType == utils.CmdTypeAllocation && displayOpts.ShowHostPorts {
 		summary.TopHostPorts = GetTopHostPortsData(results)
 	}
+
+	if cmdType == utils.CmdTypeAllocation && displayOpts.ShowTaints {
+		summary.TaintsSummary = GetTaintsSummary(results)
+	}
 	return summary, nil
 }
 
@@ -301,6 +346,10 @@ func PrintNodeResourceSummary(results []utils.NodeResult, displayOpts options.Di
 
 	if cmdType == utils.CmdTypeAllocation && displayOpts.ShowHostPorts {
 		printTopHostPorts(results, out)
+	}
+
+	if cmdType == utils.CmdTypeAllocation && displayOpts.ShowTaints {
+		printTaints(results, out)
 	}
 }
 
@@ -533,5 +582,45 @@ func printTopHostPorts(results []utils.NodeResult, out io.Writer) {
 	}
 	if len(stats) > limit {
 		fmt.Fprintf(out, "  ... and %d more ports.\n", len(stats)-limit)
+	}
+}
+
+// printTaints prints an aggregated summary of node taints.
+// This is only relevant for the 'allocation' command.
+func printTaints(results []utils.NodeResult, out io.Writer) {
+	fmt.Fprintf(out, "\nTaints by Node:\n")
+
+	taintCounts := make(map[string]int)
+	totalTaintsFound := 0
+	for _, res := range results {
+		for _, taint := range res.Taints {
+			taintCounts[taint.ToString()]++
+			totalTaintsFound++
+		}
+	}
+
+	if totalTaintsFound == 0 {
+		fmt.Fprintln(out, "  No taints in use across selected nodes.")
+		return
+	}
+
+	type taintStat struct {
+		taint string
+		count int
+	}
+	var stats []taintStat
+	for taint, count := range taintCounts {
+		stats = append(stats, taintStat{taint, count})
+	}
+
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].count != stats[j].count {
+			return stats[i].count > stats[j].count // Sort by count descending
+		}
+		return stats[i].taint < stats[j].taint // Then by taint ascending
+	})
+
+	for _, stat := range stats {
+		fmt.Fprintf(out, "  - Taint %s: Used on %d nodes\n", stat.taint, stat.count)
 	}
 }

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -30,6 +30,7 @@ type NodeResult struct {
 	CPUPercent float64
 	MemPercent float64
 	HostPorts  []int32
+	Taints     []corev1.Taint
 	FreeCPU    resource.Quantity // Added for --show-free
 	FreeMem    resource.Quantity // Added for --show-free
 


### PR DESCRIPTION
Added a --show-taints flag to include node taint information alongside labels. This is useful for our use case where scheduling constraints are important to understand when inspecting nodes.

Output examples:

```
  - Port 9090 : Used on 4 nodes
  - Port 8081: Used on 4 nodes
  ... and 5 more ports.

Taints by Node:
  - Taint example.com/test-node=true:NoSchedule: Used on 79 nodes
  - Taint example.com/dedicated=test:NoSchedule: Used on 30 nodes
```

```
      "memoryPercent": 43.85613077937003
    },
    {
      "name": "node2.example.com",
      "cpuAllocatable": "61.0",
      "cpuRequested": "56.8",
      "cpuPercent": 93.07377049180327,
      "memoryAllocatable": "371.8Gi",
      "memoryRequested": "162.2Gi",
      "memoryPercent": 43.62995105957017,
      "taints": [
        "example.com/test-node=true:NoSchedule",
        "example.com/dedicated=test:NoSchedule"
      ]
    },
    {
      "name": "node3.trading.imc.intra",
```

```
    "taintsSummary": [
      {
        "taint": "example.com/test-node=true:NoSchedule",
        "nodeCount": 79
      },
      {
        "taint": "example.com/dedicated=test:NoSchedule",
        "nodeCount": 30
      },
      {
```