### PR TITLE
fix: align padding config on header and row

### DIFF
--- a/cmd/allocation.go
+++ b/cmd/allocation.go
@@ -588,15 +588,25 @@ func newKubectlStyleTable(w io.Writer) *tablewriter.Table {
 						Alignment:  tw.AlignLeft, // force alignment for header
 						AutoFormat: tw.Off,
 					},
-					Padding: tw.CellPadding{Global: tw.PaddingNone},
+					// use two spaces for padding on the right side of header cells
+					// like kubectl does
+					Padding: tw.CellPadding{
+						Global: tw.Padding{
+							Left: tw.Empty, Right: "  ", Overwrite: true,
+						},
+					},
 				},
 				Row: tw.CellConfig{
 					Formatting: tw.CellFormatting{
 						Alignment: tw.AlignLeft, // force alightment for body
 					},
-
-					// remove all padding in a in all cells
-					Padding: tw.CellPadding{Global: tw.Padding{Right: "  "}},
+					// use two spaces for padding on the right side of header cells
+					// like kubectl does
+					Padding: tw.CellPadding{
+						Global: tw.Padding{
+							Left: tw.Empty, Right: "  ", Overwrite: true,
+						},
+					},
 				},
 			},
 		),


### PR DESCRIPTION
instead of having two different padding options for row and headers we
align the configuration on both.

We use a configuration with two spaces on the right to allign with
the configuration how kubectl does.

This is how it looks like on two different clusters (with different node-name length)

![image](https://github.com/user-attachments/assets/c986a3b2-a722-4695-b309-e5398b8e9789)
![image](https://github.com/user-attachments/assets/3629e69b-c5e4-4478-9869-908895a54e25)


closes #12 